### PR TITLE
simplify orphan lsig args check

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -1188,19 +1188,15 @@ var dryrunCmd = &cobra.Command{
 		lSigPooledSize := 0
 		lSigArgsSize := 0
 		lSigArgsNeedSizePooling := false
+		countOrphanLSigArgs := params.MaxAbsoluteLogicSigProgramSize > params.LogicSigMaxSize ||
+			params.TxnSizePricingEnabled()
+
 		for i, txn := range stxns {
-			if txn.Lsig.Blank() {
-				switch params.OrphanLogicSigArgsTreatment() {
-				case config.OrphanLogicSigArgsIgnore:
-					continue
-				case config.OrphanLogicSigArgsReject:
-					if txn.Lsig.ArgsLen() == 0 {
-						continue
-					}
-					reportErrorf("LogicSig args without LogicSig program")
-				case config.OrphanLogicSigArgsUsePool:
-					// Count below.
-				}
+			if params.TxnSizePricingEnabled() && txn.Lsig.Blank() && txn.Lsig.ArgsLen() > 0 {
+				reportErrorf("LogicSig args without LogicSig program")
+			}
+			if txn.Lsig.Blank() && !countOrphanLSigArgs {
+				continue
 			}
 			lSigPooledSize += txn.Lsig.Len()
 			lSigArgsSize += txn.Lsig.ArgsLen()

--- a/config/consensus.go
+++ b/config/consensus.go
@@ -702,32 +702,6 @@ func (proto ConsensusParams) TxnSizePricingEnabled() bool {
 	return proto.PerByteTxnSurcharge != 0
 }
 
-// OrphanLogicSigArgsTreatment describes how consensus handles Lsig.Args when
-// Lsig.Logic is empty. Such args were ignored before LogicSig size pooling,
-// counted in the LogicSig size pool after pooling, and rejected once
-// transaction size pricing is enabled.
-type OrphanLogicSigArgsTreatment int
-
-// OrphanLogicSigArgsTreatment values.
-const (
-	OrphanLogicSigArgsIgnore OrphanLogicSigArgsTreatment = iota
-	OrphanLogicSigArgsUsePool
-	OrphanLogicSigArgsReject
-)
-
-// OrphanLogicSigArgsTreatment returns the consensus handling for args on a
-// blank LogicSig.
-func (proto ConsensusParams) OrphanLogicSigArgsTreatment() OrphanLogicSigArgsTreatment {
-	switch {
-	case proto.TxnSizePricingEnabled():
-		return OrphanLogicSigArgsReject
-	case proto.MaxAbsoluteLogicSigProgramSize > proto.LogicSigMaxSize:
-		return OrphanLogicSigArgsUsePool
-	default:
-		return OrphanLogicSigArgsIgnore
-	}
-}
-
 // EffectiveKeyDilution returns the key dilution for this account,
 // returning the default key dilution if not explicitly specified.
 func (proto ConsensusParams) EffectiveKeyDilution(kd uint64) uint64 {

--- a/data/transactions/verify/txn.go
+++ b/data/transactions/verify/txn.go
@@ -223,6 +223,14 @@ func txnGroupBatchPrep(stxs []transactions.SignedTxn, contextHdr *bookkeeping.Bl
 		if err := stxs[i].Txn.WellFormed(groupCtx.specAddrs, groupCtx.consensusParams); err != nil {
 			return nil, fmt.Errorf("transaction %+v invalid : %w", stxs[i], &TxGroupError{err: err, GroupIndex: i, Reason: TxGroupErrorReasonNotWellFormed})
 		}
+		// with PerByteTxnSurcharge orphan LogicSig args are not allowed
+		if groupCtx.consensusParams.TxnSizePricingEnabled() && stxs[i].Lsig.Blank() && stxs[i].Lsig.ArgsLen() > 0 {
+			return nil, &TxGroupError{
+				err:        errors.New("LogicSig args without LogicSig program"),
+				GroupIndex: i,
+				Reason:     TxGroupErrorReasonNotWellFormed,
+			}
+		}
 	}
 
 	if err := transactions.CheckTxnGroup(stxs); err != nil {
@@ -232,6 +240,9 @@ func txnGroupBatchPrep(stxs []transactions.SignedTxn, contextHdr *bookkeeping.Bl
 	lSigPooledSize := 0
 	lSigArgsSize := 0
 	lSigArgsNeedSizePooling := false
+
+	countOrphanLSigArgs := groupCtx.consensusParams.MaxAbsoluteLogicSigProgramSize > groupCtx.consensusParams.LogicSigMaxSize ||
+		groupCtx.consensusParams.TxnSizePricingEnabled()
 	for i, stxn := range stxs {
 		prepErr := txnBatchPrep(i, groupCtx, batch)
 		if prepErr != nil {
@@ -239,22 +250,10 @@ func txnGroupBatchPrep(stxs []transactions.SignedTxn, contextHdr *bookkeeping.Bl
 			prepErr.err = fmt.Errorf("transaction %+v invalid : %w", stxn, prepErr.err)
 			return nil, prepErr
 		}
-		if stxn.Lsig.Blank() {
-			switch groupCtx.consensusParams.OrphanLogicSigArgsTreatment() {
-			case config.OrphanLogicSigArgsIgnore:
-				continue
-			case config.OrphanLogicSigArgsReject:
-				if stxn.Lsig.ArgsLen() > 0 {
-					return nil, &TxGroupError{
-						err:        errors.New("LogicSig args without LogicSig program"),
-						GroupIndex: i,
-						Reason:     TxGroupErrorReasonNotWellFormed,
-					}
-				}
-			case config.OrphanLogicSigArgsUsePool:
-				// Count below.
-			}
+		if stxn.Lsig.Blank() && !countOrphanLSigArgs {
+			continue
 		}
+
 		lSigPooledSize += stxn.Lsig.Len()
 		lSigArgsSize += stxn.Lsig.ArgsLen()
 		if uint64(stxn.Lsig.ArgsLen()) > groupCtx.consensusParams.MaxLogicSigArgsSize {


### PR DESCRIPTION
Remove `OrphanLogicSigArgsTreatment` type and integrate check in-place